### PR TITLE
Hex compatable endpoints

### DIFF
--- a/space2stats_api/src/space2stats/api/app.py
+++ b/space2stats_api/src/space2stats/api/app.py
@@ -15,7 +15,12 @@ from .. import __version__
 from ..lib import StatsTable
 from .db import close_db_connection, connect_to_db
 from .errors import add_exception_handlers
-from .schemas import AggregateRequest, SummaryRequest
+from .schemas import (
+    AggregateRequest,
+    HexIdAggregateRequest,
+    HexIdSummaryRequest,
+    SummaryRequest,
+)
 from .settings import Settings
 
 s3_client = boto3.client("s3")
@@ -144,6 +149,52 @@ def build_app(settings: Optional[Settings] = None) -> FastAPI:
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
+    @app.post("/summary_by_hexids", response_model=List[Dict[str, Any]])
+    def get_summary_by_hexids(
+        body: HexIdSummaryRequest, table: StatsTable = Depends(stats_table)
+    ):
+        """Retrieve statistics for specific hex IDs.
+
+        Parameters
+        ----------
+        <dl>
+        <dt>hex_ids</dt>
+        <dd>
+        `List[str]`
+
+        List of H3 hexagon IDs to query
+        </dd>
+
+        <dt>fields</dt>
+        <dd>
+        `List[str]`
+
+        List of field names to retrieve from the statistics table
+        </dd>
+
+        <dt>geometry</dt>
+        <dd>
+        `Optional["polygon", "point"]`
+
+        Specifies if the H3 geometries should be included in the response
+        </dd>
+        </dl>
+
+        Returns
+        -------
+        `List[Dict]`
+
+        List of dictionaries containing statistics for each hex ID
+        """
+        try:
+            return table.summaries_by_hexids(
+                hex_ids=body.hex_ids,
+                fields=body.fields,
+                geometry=body.geometry,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
     @app.post("/aggregate", response_model=Dict[str, float])
     def get_aggregate(body: AggregateRequest, table: StatsTable = Depends(stats_table)):
         """Aggregate Statistics from a GeoJSON feature.
@@ -203,6 +254,52 @@ def build_app(settings: Optional[Settings] = None) -> FastAPI:
             )
         except pg.errors.UndefinedColumn as e:
             raise HTTPException(status_code=400, detail=e.diag.message_primary) from e
+
+    @app.post("/aggregate_by_hexids", response_model=Dict[str, float])
+    def get_aggregate_by_hexids(
+        body: HexIdAggregateRequest, table: StatsTable = Depends(stats_table)
+    ):
+        """Aggregate statistics for specific hex IDs.
+
+        Parameters
+        ----------
+        <dl>
+        <dt>hex_ids</dt>
+        <dd>
+        `List[str]`
+
+        List of H3 hexagon IDs to aggregate
+        </dd>
+
+        <dt>fields</dt>
+        <dd>
+        `List[str]`
+
+        List of field names to aggregate
+        </dd>
+
+        <dt>aggregation_type</dt>
+        <dd>
+        `["sum", "avg", "count", "max", "min"]`
+
+        Type of aggregation to perform on the fields
+        </dd>
+        </dl>
+
+        Returns
+        -------
+        `Dict[str, float]`
+
+        Dictionary containing aggregated statistics for the specified hex IDs
+        """
+        try:
+            return table.aggregate_by_hexids(
+                hex_ids=body.hex_ids,
+                fields=body.fields,
+                aggregation_type=body.aggregation_type,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
     @app.get("/fields", response_model=List[str])
     def fields(table: StatsTable = Depends(stats_table)):

--- a/space2stats_api/src/space2stats/api/app.py
+++ b/space2stats_api/src/space2stats/api/app.py
@@ -174,17 +174,20 @@ def build_app(settings: Optional[Settings] = None) -> FastAPI:
 
         <dt>geometry</dt>
         <dd>
-        `Optional["polygon", "point"]`
+        `Literal["polygon", "point"] | None`
 
-        Specifies if the H3 geometries should be included in the response
+        Specifies if the H3 geometries should be included in the response. It can be either "polygon" to get hexagon boundaries, "point" to get hexagon centers, or None to exclude geometries.
         </dd>
         </dl>
 
         Returns
         -------
-        `List[Dict]`
+        `List[Dict[str, Any]]`
 
-        List of dictionaries containing statistics for each hex ID
+        List of dictionaries containing statistics for each hex ID. Each dictionary contains:
+        - `hex_id`: The H3 cell identifier
+        - `geometry` (optional): The geometry of the H3 cell, if geometry is specified
+        - Other fields from the statistics table, based on the specified `fields`
         """
         try:
             return table.summaries_by_hexids(

--- a/space2stats_api/src/space2stats/api/schemas.py
+++ b/space2stats_api/src/space2stats/api/schemas.py
@@ -13,8 +13,20 @@ class SummaryRequest(BaseModel):
     geometry: Optional[Literal["polygon", "point"]] = None
 
 
+class HexIdSummaryRequest(BaseModel):
+    hex_ids: List[str]
+    fields: List[str]
+    geometry: Optional[Literal["polygon", "point"]] = None
+
+
 class AggregateRequest(BaseModel):
     aoi: Feature
     spatial_join_method: Literal["touches", "centroid", "within"]
+    fields: List[str]
+    aggregation_type: Literal["sum", "avg", "count", "max", "min"]
+
+
+class HexIdAggregateRequest(BaseModel):
+    hex_ids: List[str]
     fields: List[str]
     aggregation_type: Literal["sum", "avg", "count", "max", "min"]

--- a/space2stats_api/src/space2stats/lib.py
+++ b/space2stats_api/src/space2stats/lib.py
@@ -37,36 +37,22 @@ class StatsTable:
         if self.conn:
             self.conn.close()
 
-    def _get_summaries(self, fields: List[str], h3_ids: List[int]):
-        colnames = ["hex_id"] + fields
-        cols = [pg.sql.Identifier(c) for c in colnames]
-        sql_query = pg.sql.SQL(
-            """
-                SELECT {0}
-                FROM {1}
-                WHERE hex_id = ANY (%s)
-                ORDER BY array_position(%s, hex_id)
-            """
-        ).format(pg.sql.SQL(", ").join(cols), pg.sql.Identifier(self.table_name))
-
-        # Convert h3_ids to integers to ensure compatibility with psycopg
-        h3_ids = [
-            scalar.as_py() if hasattr(scalar, "as_py") else scalar for scalar in h3_ids
-        ]
-        h3_id_strings = cells_to_string(h3_ids).to_pylist()
+    def fields(self) -> List[str]:
+        """Get available fields from the statistics table."""
+        sql_query = """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = %s
+        """
 
         with self.conn.cursor() as cur:
             cur.execute(
                 sql_query,
-                [
-                    h3_id_strings,
-                    h3_id_strings,
-                ],  # Pass h3_id_strings twice: once for ANY, once for array_position
+                [self.table_name],
             )
-            rows = cur.fetchall()
-            colnames = [desc[0] for desc in cur.description]
+            columns = [row[0] for row in cur.fetchall() if row[0] != "hex_id"]
 
-        return rows, colnames
+        return columns
 
     def summaries(
         self,
@@ -74,40 +60,29 @@ class StatsTable:
         spatial_join_method: Literal["touches", "centroid", "within"],
         fields: List[str],
         geometry: Optional[Literal["polygon", "point"]] = None,
-    ):
+    ) -> List[Dict]:
         """Retrieve Statistics from a GeoJSON feature.
 
         Parameters
         ----------
         aoi : GeoJSON Feature
             The Area of Interest, either as a `Feature` or an instance of `AoiModel`
-
         spatial_join_method : ["touches", "centroid", "within"]
             The method to use for performing the spatial join between the AOI and H3 cells
-                - "touches": Includes H3 cells that touch the AOI
-                - "centroid": Includes H3 cells where the centroid falls within the AOI
-                - "within": Includes H3 cells entirely within the AOI
-
         fields : List[str]
-            A list of field names to retrieve from the statistics table.
-
+            A list of field names to retrieve from the statistics table
         geometry : Optional["polygon", "point"]
-            Specifies if the H3 geometries should be included in the response. It can be either "polygon" or "point". If None, geometries are not included
+            Specifies if the H3 geometries should be included in the response
 
         Returns
         -------
         List[Dict]
-            A list of dictionaries containing statistical summaries for each H3 cell. Each dictionary contains:
-                - "hex_id": The H3 cell identifier
-                - "geometry" (optional): The geometry of the H3 cell, if geometry is specified.
-                - Other fields from the statistics table, based on the specified `fields`
+            A list of dictionaries containing statistical summaries for each H3 cell
         """
         if not isinstance(aoi, Feature):
             aoi = AoiModel.model_validate(aoi)
 
-        invalid_fields = [field for field in fields if field not in self.fields()]
-        if invalid_fields:
-            raise ValueError(f"Invalid fields: {invalid_fields}")
+        self._validate_fields(fields)
 
         # Get H3 ids from geometry
         resolution = 6
@@ -125,7 +100,140 @@ class StatsTable:
         if not rows:
             return []
 
-        # Format Summaries
+        return self._format_summaries(rows, colnames, fields, h3_ids, geometry)
+
+    def summaries_by_hexids(
+        self,
+        hex_ids: List[str],
+        fields: List[str],
+        geometry: Optional[Literal["polygon", "point"]] = None,
+    ) -> List[Dict]:
+        """Retrieve statistics for specific hex IDs.
+
+        Parameters
+        ----------
+        hex_ids : List[str]
+            List of H3 hexagon IDs to query
+        fields : List[str]
+            List of fields to retrieve
+        geometry : Optional[Literal["polygon", "point"]]
+            If specified, includes H3 cell geometries in the response
+
+        Returns
+        -------
+        List[Dict]
+            List of dictionaries containing statistics for each hex ID
+        """
+        self._validate_fields(fields)
+
+        # Convert hex_ids to integers
+        h3_ids = [int(h, 16) for h in hex_ids]
+
+        # Get summaries from H3 ids
+        rows, colnames = self._get_summaries(fields=fields, h3_ids=h3_ids)
+        if not rows:
+            return []
+
+        return self._format_summaries(rows, colnames, fields, h3_ids, geometry)
+
+    def aggregate(
+        self,
+        aoi: AoiModel,
+        spatial_join_method: Literal["touches", "centroid", "within"],
+        fields: List[str],
+        aggregation_type: Literal["sum", "avg", "count", "max", "min"],
+    ) -> Dict[str, float]:
+        """Aggregate Statistics from a GeoJSON feature."""
+        if not isinstance(aoi, Feature):
+            aoi = AoiModel.model_validate(aoi)
+
+        self._validate_fields(fields)
+
+        # Get H3 ids from geometry
+        resolution = 6
+        h3_ids = list(
+            generate_h3_ids(
+                aoi.geometry.model_dump(exclude_none=True),
+                resolution,
+                spatial_join_method,
+            )
+        )
+
+        if not h3_ids:
+            return {}
+
+        return self._aggregate_by_h3_ids(h3_ids, fields, aggregation_type)
+
+    def aggregate_by_hexids(
+        self,
+        hex_ids: List[str],
+        fields: List[str],
+        aggregation_type: Literal["sum", "avg", "count", "max", "min"],
+    ) -> Dict[str, float]:
+        """Aggregate statistics for specific hex IDs.
+
+        Parameters
+        ----------
+        hex_ids : List[str]
+            List of H3 hexagon IDs to aggregate
+        fields : List[str]
+            List of fields to aggregate
+        aggregation_type : Literal["sum", "avg", "count", "max", "min"]
+            Type of aggregation to perform
+
+        Returns
+        -------
+        Dict[str, float]
+            Dictionary containing aggregated statistics
+        """
+        self._validate_fields(fields)
+
+        # Convert hex_ids to integers
+        h3_ids = [int(h, 16) for h in hex_ids]
+
+        return self._aggregate_by_h3_ids(h3_ids, fields, aggregation_type)
+
+    def _validate_fields(self, fields: List[str]) -> None:
+        """Validate that requested fields exist in the database."""
+        invalid_fields = [field for field in fields if field not in self.fields()]
+        if invalid_fields:
+            raise ValueError(f"Invalid fields: {invalid_fields}")
+
+    def _get_summaries(self, fields: List[str], h3_ids: List[int]):
+        """Internal method to fetch summaries from database."""
+        colnames = ["hex_id"] + fields
+        cols = [pg.sql.Identifier(c) for c in colnames]
+        sql_query = pg.sql.SQL(
+            """
+                SELECT {0}
+                FROM {1}
+                WHERE hex_id = ANY (%s)
+                ORDER BY array_position(%s, hex_id)
+            """
+        ).format(pg.sql.SQL(", ").join(cols), pg.sql.Identifier(self.table_name))
+
+        # Convert h3_ids to strings
+        h3_id_strings = cells_to_string(h3_ids).to_pylist()
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                sql_query,
+                [h3_id_strings, h3_id_strings],
+            )
+            rows = cur.fetchall()
+            colnames = [desc[0] for desc in cur.description]
+
+        return rows, colnames
+
+    def _format_summaries(
+        self,
+        rows: List[tuple],
+        colnames: List[str],
+        fields: List[str],
+        h3_ids: List[int],
+        geometry: Optional[Literal["polygon", "point"]],
+    ) -> List[Dict]:
+        """Internal method to format summary results."""
         summaries: List[Dict] = []
         geometries = generate_h3_geometries(h3_ids, geometry) if geometry else None
 
@@ -145,54 +253,17 @@ class StatsTable:
 
         return summaries
 
-    def fields(self) -> List[str]:
-        sql_query = """
-            SELECT column_name
-            FROM information_schema.columns
-            WHERE table_name = %s
-        """
-
-        with self.conn.cursor() as cur:
-            cur.execute(
-                sql_query,
-                [self.table_name],
-            )
-            columns = [row[0] for row in cur.fetchall() if row[0] != "hex_id"]
-
-        return columns
-
-    def aggregate(
+    def _aggregate_by_h3_ids(
         self,
-        aoi: AoiModel,
-        spatial_join_method: Literal["touches", "centroid", "within"],
+        h3_ids: List[int],
         fields: List[str],
         aggregation_type: Literal["sum", "avg", "count", "max", "min"],
     ) -> Dict[str, float]:
-        """Aggregate Statistics from a GeoJSON feature."""
-        if not isinstance(aoi, Feature):
-            aoi = AoiModel.model_validate(aoi)
-
-        invalid_fields = [field for field in fields if field not in self.fields()]
-        if invalid_fields:
-            raise ValueError(f"Invalid fields: {invalid_fields}")
-
-        # Get H3 ids from geometry
-        resolution = 6
-        h3_ids = list(
-            generate_h3_ids(
-                aoi.geometry.model_dump(exclude_none=True),
-                resolution,
-                spatial_join_method,
-            )
-        )
-
+        """Internal method to perform aggregation on H3 IDs."""
         # Convert H3 scalar objects to integers
         h3_ids = [
             scalar.as_py() if hasattr(scalar, "as_py") else scalar for scalar in h3_ids
         ]
-
-        if not h3_ids:
-            return {}
 
         # Prepare SQL aggregation query
         aggregations = [f"{aggregation_type}({field}) AS {field}" for field in fields]
@@ -212,7 +283,7 @@ class StatsTable:
                 sql_query,
                 [cells_to_string(h3_ids).to_pylist()],
             )
-            row = cur.fetchone()  # Get a single row of results
+            row = cur.fetchone()
             colnames = [desc[0] for desc in cur.description]
 
         # Create a dictionary to hold the aggregation results

--- a/space2stats_api/src/space2stats/lib.py
+++ b/space2stats_api/src/space2stats/lib.py
@@ -69,6 +69,9 @@ class StatsTable:
             The Area of Interest, either as a `Feature` or an instance of `AoiModel`
         spatial_join_method : ["touches", "centroid", "within"]
             The method to use for performing the spatial join between the AOI and H3 cells
+                - "touches": Includes H3 cells that touch the AOI
+                - "centroid": Includes H3 cells where the centroid falls within the AOI
+                - "within": Includes H3 cells entirely within the AOI
         fields : List[str]
             A list of field names to retrieve from the statistics table
         geometry : Optional["polygon", "point"]
@@ -77,7 +80,10 @@ class StatsTable:
         Returns
         -------
         List[Dict]
-            A list of dictionaries containing statistical summaries for each H3 cell
+            A list of dictionaries containing statistical summaries for each H3 cell. Each dictionary contains:
+                - "hex_id": The H3 cell identifier
+                - "geometry" (optional): The geometry of the H3 cell, if geometry is specified.
+                - Other fields from the statistics table, based on the specified `fields`
         """
         if not isinstance(aoi, Feature):
             aoi = AoiModel.model_validate(aoi)


### PR DESCRIPTION
# Add Hex ID Endpoints

## What I Changed:
- Added new methods to StatsTable to handle direct h3 AOI inputs
- Added new endpoints:
  - `/summary_by_hexids`: Get statistics by H3 IDs
  - `/aggregate_by_hexids`: Aggregate statistics across H3 IDs
- Added test coverage for new endpoints

## How to Test:
- Run tests with ```pytest```
- Or run server locally and make manual API requests through the ```http://localhost:8000/docs``` url