### PR TITLE
Client Update: add option to bypass ssl verification

### DIFF
--- a/space2stats_client/pyproject.toml
+++ b/space2stats_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "space2stats-client"
-version = "1.1.1"
+version = "1.1.2"
 description = "A Python client for accessing sub-national variation data through the Space2Stats API"
 readme = "README.md"
 authors = [{name = "Gabe Levin", email = "glevin@worldbank.org"}, {name = "Andres Chamorro", email = "achamorroelizond@worldbank.org"}]

--- a/space2stats_client/src/space2stats_client/__init__.py
+++ b/space2stats_client/src/space2stats_client/__init__.py
@@ -2,6 +2,6 @@
 
 from .client import Space2StatsClient
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __license__ = "World Bank Master Community License Agreement"
 __copyright__ = "Copyright (c) 2025 The World Bank"

--- a/space2stats_client/src/space2stats_client/client.py
+++ b/space2stats_client/src/space2stats_client/client.py
@@ -16,15 +16,23 @@ class Space2StatsClient:
     completeness of the results and content.
     """
 
-    def __init__(self, base_url: str = "https://space2stats.ds.io"):
+    def __init__(
+        self, base_url: str = "https://space2stats.ds.io", verify_ssl: bool = True
+    ):
         """Initialize the Space2Stats client.
 
         Parameters
         ----------
         base_url : str
             Base URL for the Space2Stats API
+        verify_ssl : bool
+            Whether to verify SSL certificates in requests (default: True)
         """
+        if not isinstance(verify_ssl, bool):
+            raise TypeError("verify_ssl must be a boolean value (True or False)")
+
         self.base_url = base_url
+        self.verify_ssl = verify_ssl
         self.summary_endpoint = f"{base_url}/summary"
         self.aggregation_endpoint = f"{base_url}/aggregate"
         self.fields_endpoint = f"{base_url}/fields"
@@ -71,17 +79,16 @@ class Space2StatsClient:
         Exception
             If the API request fails.
         """
-        response = requests.get(self.fields_endpoint)
+        response = requests.get(self.fields_endpoint, verify=self.verify_ssl)
         if response.status_code != 200:
             raise Exception(f"Failed to get fields: {response.text}")
 
         return response.json()
 
-    @staticmethod
-    def fetch_admin_boundaries(iso3: str, adm: str) -> gpd.GeoDataFrame:
+    def fetch_admin_boundaries(self, iso3: str, adm: str) -> gpd.GeoDataFrame:
         """Fetch administrative boundaries from GeoBoundaries API."""
         url = f"https://www.geoboundaries.org/api/current/gbOpen/{iso3}/{adm}/"
-        res = requests.get(url).json()
+        res = requests.get(url, verify=self.verify_ssl).json()
         return gpd.read_file(res["gjDownloadURL"])
 
     def get_summary(
@@ -127,7 +134,9 @@ class Space2StatsClient:
                 "fields": fields,
                 "geometry": geometry,
             }
-            response = requests.post(self.summary_endpoint, json=request_payload)
+            response = requests.post(
+                self.summary_endpoint, json=request_payload, verify=self.verify_ssl
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Failed to get summary: {response.text}")
@@ -187,7 +196,9 @@ class Space2StatsClient:
                 "fields": fields,
                 "aggregation_type": aggregation_type,
             }
-            response = requests.post(self.aggregation_endpoint, json=request_payload)
+            response = requests.post(
+                self.aggregation_endpoint, json=request_payload, verify=self.verify_ssl
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Failed to get aggregate: {response.text}")
@@ -233,7 +244,9 @@ class Space2StatsClient:
             "geometry": geometry,
         }
         response = requests.post(
-            f"{self.base_url}/summary_by_hexids", json=request_payload
+            f"{self.base_url}/summary_by_hexids",
+            json=request_payload,
+            verify=self.verify_ssl,
         )
 
         if response.status_code != 200:
@@ -270,7 +283,9 @@ class Space2StatsClient:
             "aggregation_type": aggregation_type,
         }
         response = requests.post(
-            f"{self.base_url}/aggregate_by_hexids", json=request_payload
+            f"{self.base_url}/aggregate_by_hexids",
+            json=request_payload,
+            verify=self.verify_ssl,
         )
 
         if response.status_code != 200:


### PR DESCRIPTION
## What I changed
- I added the option to bypass the ssl verification via the python client
- close #119 

## How to test is
1. checkout this branch
2. cd to space2stats_client
3. run ```pip install -e .```
4. see section below

## How to use it
```
from space2stats_client import Space2StatsClient

# Create a client with SSL verification disabled
client = Space2StatsClient(verify_ssl=False)

# Now all API calls made with this client will bypass SSL verification
fields = client.get_fields()
```
