### PR TITLE
Feat/improved error handling

### DIFF
--- a/space2stats_api/src/space2stats/api/errors.py
+++ b/space2stats_api/src/space2stats/api/errors.py
@@ -12,6 +12,18 @@ async def database_exception_handler(request: Request, exc: OperationalError):
 
 
 async def http_exception_handler(request: Request, exc: HTTPException):
+    # Special handling for 413 errors
+    if exc.status_code == 413:
+        return JSONResponse(
+            status_code=413,
+            content={
+                "error": "Request Entity Too Large",
+                "detail": "The request payload exceeds the API limits",
+                "hint": "Try again with a smaller request or making multiple requests with smaller payloads. The factors to consider are the number of hexIds (ie. AOI), the number of fields requested, and the date range (if timeseries is requested).",
+            },
+        )
+
+    # Default handling for all other HTTP exceptions
     return JSONResponse(
         status_code=exc.status_code,
         content={"error": exc.detail},

--- a/space2stats_api/src/tests/conftest.py
+++ b/space2stats_api/src/tests/conftest.py
@@ -96,6 +96,7 @@ def mock_env(monkeypatch, database):
     monkeypatch.setenv("PGPASSWORD", database.password)
     monkeypatch.setenv("PGTABLENAME", "space2stats")
     monkeypatch.setenv("S3_BUCKET_NAME", "mybucket")
+    monkeypatch.setenv("TIMESERIES_TABLE_NAME", "climate")
 
 
 @pytest.fixture

--- a/space2stats_api/src/tests/test_errors.py
+++ b/space2stats_api/src/tests/test_errors.py
@@ -68,3 +68,19 @@ def test_validation_exception_handler():
     assert response.status_code == 422
     response_data = json.loads(response.body.decode("utf-8"))
     assert response_data == expected_response
+
+
+def test_http_exception_handler_413():
+    request = None
+    exception = HTTPException(status_code=413, detail="Request Entity Too Large")
+    response = asyncio.run(http_exception_handler(request, exception))
+
+    expected_response = {
+        "error": "Request Entity Too Large",
+        "detail": "The request payload exceeds the API limits",
+        "hint": "Try again with a smaller request or making multiple requests with smaller payloads. The factors to consider are the number of hexIds (ie. AOI), the number of fields requested, and the date range (if timeseries is requested).",
+    }
+
+    assert response.status_code == 413
+    response_data = json.loads(response.body.decode("utf-8"))
+    assert response_data == expected_response

--- a/space2stats_client/tests/conftest.py
+++ b/space2stats_client/tests/conftest.py
@@ -177,3 +177,38 @@ def mock_api_response(mocker, mock_catalog):
     mocker.patch("pystac.Catalog.from_file", return_value=mock_catalog)
 
     return mock_response
+
+
+@pytest.fixture
+def mock_error_response_413(mocker):
+    """Mock response for 413 Request Entity Too Large error."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 413
+    mock_response.json.return_value = {
+        "error": "Request Entity Too Large",
+        "detail": "The request payload exceeds the API limits",
+        "hint": "Try again with a smaller request or making multiple requests with smaller payloads. The factors to consider are the number of hexIds (ie. AOI), the number of fields requested, and the date range (if timeseries data is requested).",
+    }
+    return mock_response
+
+
+@pytest.fixture
+def mock_error_response_400(mocker):
+    """Mock response for 400 Bad Request error with JSON response."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 400
+    mock_response.json.return_value = {
+        "error": "Bad Request",
+        "detail": "Invalid request parameters",
+    }
+    return mock_response
+
+
+@pytest.fixture
+def mock_error_response_500(mocker):
+    """Mock response for 500 Internal Server Error with plain text."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 500
+    mock_response.json.side_effect = ValueError("Not JSON")
+    mock_response.text = "Internal Server Error"
+    return mock_response

--- a/space2stats_client/tests/test_client.py
+++ b/space2stats_client/tests/test_client.py
@@ -232,3 +232,43 @@ def test_get_timeseries_by_hexids_values(mock_api_response):
     # Check a specific value from the second hex_id
     assert "2024-01-03" in second_hex_data["date"].values
     assert 1.5 in second_hex_data["value"].values
+
+
+def test_handle_api_error_413(mock_error_response_413):
+    """Test handling of 413 Request Entity Too Large error."""
+    client = Space2StatsClient()
+
+    with pytest.raises(Exception) as exc_info:
+        client._handle_api_error(mock_error_response_413)
+
+    expected_message = (
+        "Failed to test_handle_api_error_413 (HTTP 413): The request payload exceeds the API limits\n"
+        "Hint: Try again with a smaller request or making multiple requests with smaller payloads. "
+        "The factors to consider are the number of hexIds (ie. AOI), the number of fields requested, "
+        "and the date range (if timeseries data is requested)."
+    ).strip()
+    assert str(exc_info.value).strip() == expected_message
+
+
+def test_handle_api_error_generic(mock_error_response_400):
+    """Test handling of generic API errors."""
+    client = Space2StatsClient()
+
+    with pytest.raises(Exception) as exc_info:
+        client._handle_api_error(mock_error_response_400)
+
+    expected_message = (
+        "Failed to test_handle_api_error_generic (HTTP 400): Invalid request parameters"
+    ).strip()
+    assert str(exc_info.value).strip() == expected_message
+
+
+def test_handle_api_error_non_json(mock_error_response_500):
+    """Test handling of non-JSON error responses."""
+    client = Space2StatsClient()
+
+    with pytest.raises(Exception) as exc_info:
+        client._handle_api_error(mock_error_response_500)
+
+    assert "HTTP 500" in str(exc_info.value)
+    assert "Internal Server Error" in str(exc_info.value)


### PR DESCRIPTION
# What I Changed
- Added 413 error handling to the exception handler in FastAPI
- Updated Client to inherit the errors from the api more gracefully

# How to Test
- Run the server locally and download v1.2.1 of the client locally
- Make a too large request i.e. 10,000 hex and 65 fields to get_summary_by_hexids

# Note
- After some deliberation, I think it might actually be better to keep the error message vague in terms of how much data we can accept and/or giving examples of requests that are right on the edge or limit. The reason is there is too much variation in the possible combinations of AOI (i.e. # of hexagons), # of fields, and the date range. Being too prescriptive could make things even more confusing. Instead, I have opted for a more generic hint in the error message:

```
"error": "Request Entity Too Large",
"detail": "The request payload exceeds the API limits",
"hint": "Try again with a smaller request or making multiple requests with smaller payloads. The factors to consider are the number of hexIds (ie. AOI), the number of fields requested, and the date range (if timeseries is requested)."
```





