### PR TITLE
Adm2 summary client method

### DIFF
--- a/space2stats_client/README.md
+++ b/space2stats_client/README.md
@@ -97,6 +97,30 @@ Gets timeseries data for specific H3 hexagon IDs.
   - `geometry`: Optional "polygon" or "point" to include H3 geometries
   - `verbose`: Optional boolean to display progress messages
 
+---
+
+## ADM2 Summaries
+
+Access pre-computed administrative level 2 (ADM2) summaries from the World Bank Development Data Hub.
+
+### `get_adm2_dataset_info()`
+Returns information about available ADM2 datasets.
+- **Returns:** DataFrame with dataset names, resource IDs, descriptions, and URLs
+
+---
+
+### `get_adm2_summaries(dataset, iso3_filter=None)`
+Retrieves ADM2-level summary statistics from the World Bank DDH API.
+- **Parameters:**
+  - `dataset`: Dataset to retrieve. Options:
+    - `"urbanization"`: Urban and rural settlement data (GHS settlement model)
+    - `"nighttimelights"`: Nighttime lights intensity data (satellite-derived luminosity)
+    - `"population"`: Population statistics (demographic data)
+    - `"flood_exposure"`: Flood exposure risk data (flood hazard and exposure metrics)
+  - `iso3_filter`: Optional ISO3 country code to filter by (e.g., 'USA', 'BRA', 'IND')
+  - `verbose`: Optional boolean to display progress messages
+- **Returns:** DataFrame containing ADM2-level statistics records
+
 ## Interactive Widgets
 
 Space2Stats provides interactive widgets that make it easy to explore and select data fields in Jupyter notebooks.
@@ -176,11 +200,7 @@ client = Space2StatsClient()
 topics = client.get_topics()
 print(topics)
 
-<<<<<<< HEAD
-# Get fields for all datasets
-=======
 # Get fields for a specific dataset
->>>>>>> main
 fields = client.get_fields()
 print(fields)
 
@@ -211,14 +231,15 @@ timeseries = client.get_timeseries(
     geometry="polygon"         # Optional
 )
 
-# Get time series data
-timeseries = client.get_timeseries(
-    gdf=gdf,
-    spatial_join_method="centroid",
-    fields=["spi"],
-    start_date="2020-01-01",
-    end_date="2020-12-31"
+# Get ADM2 summaries for a specific country
+adm2_pop = client.get_adm2_summaries(
+    dataset="population",
+    iso3_filter="USA"  # Optional country filter
 )
+
+# Get all available ADM2 datasets info
+adm2_info = client.get_adm2_dataset_info()
+print(adm2_info)
 ```
 
 ## Documentation

--- a/space2stats_client/pyproject.toml
+++ b/space2stats_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "space2stats-client"
-version = "1.3.0"
+version = "1.3.1"
 description = "A Python client for accessing sub-national variation data through the Space2Stats API"
 readme = "README.md"
 authors = [{name = "Gabe Levin", email = "glevin@worldbank.org"}, {name = "Andres Chamorro", email = "achamorroelizond@worldbank.org"}]

--- a/space2stats_client/src/space2stats_client/__init__.py
+++ b/space2stats_client/src/space2stats_client/__init__.py
@@ -4,6 +4,6 @@ from .client import Space2StatsClient
 from .widgets.cross_section_field_selector import CrossSectionFieldSelector
 from .widgets.time_series_field_selector import TimeSeriesFieldSelector
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __license__ = "World Bank Master Community License Agreement"
 __copyright__ = "Copyright (c) 2025 The World Bank"


### PR DESCRIPTION
# What I changed
- New methods to get the adm2 summary data from ddh and return a pandas dataframe
- Methods to see the available adm2 summary tables

# How to test
``` python
# Initialize the client
client = Space2StatsClient()
# Get info about available data
dataset_info = client.get_adm2_dataset_info()
dataset_info
# Get summary data
urban_countries = client.get_adm2_summaries("urbanization", "AND")
urban_countries
``` 