### PR TITLE
Bump client version to 1.4.0

### DIFF
--- a/space2stats_client/pyproject.toml
+++ b/space2stats_client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "space2stats-client"
-version = "1.3.1"
+version = "1.4.0"
 description = "A Python client for accessing sub-national variation data through the Space2Stats API"
 readme = "README.md"
 authors = [{name = "Gabe Levin", email = "glevin@worldbank.org"}, {name = "Andres Chamorro", email = "achamorroelizond@worldbank.org"}]

--- a/space2stats_client/src/space2stats_client/__init__.py
+++ b/space2stats_client/src/space2stats_client/__init__.py
@@ -2,7 +2,7 @@
 
 from .client import Space2StatsClient
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 __license__ = "World Bank Master Community License Agreement"
 __copyright__ = "Copyright (c) 2025 The World Bank"
 


### PR DESCRIPTION
Since we’ve introduced net-new, user-facing features (the AOI selector widget and ADM2 summary methods) rather than just bug-fixes, you should bump the minor version.