### PR TITLE
fix: add widgets to CI install cmd

### DIFF
--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -26,7 +26,7 @@ jobs:
         
       - name: Install dependencies
         run: |
-          poetry install --with test
+          poetry install --with test,widgets
 
       - name: Run tests
         run: poetry run pytest


### PR DESCRIPTION
This should fix the client deployment error. With the new widget structure an additional command is required for installing the widget specific dependencies, ie. ipywidgets, etc.