### PR TITLE
Fix client release error

### DIFF
--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -3,6 +3,7 @@ name: Client Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -26,7 +27,8 @@ jobs:
         
       - name: Install dependencies
         run: |
-          poetry install --with test,widgets
+          poetry install --with test
+          poetry run pip install -e .[widgets]
 
       - name: Run tests
         run: poetry run pytest


### PR DESCRIPTION
# What I changed:

To fix the dependency error in the client-release test workflow for the widgets, I moved the install command to its own line and specified installation in editable mode.

```poetry run pip install -e .[widgets]```

Additionally, I added a workflow_dispatch in order to test the workflow without triggering an actual release. All tests passed after running the following:

```gh workflow run "Client Release" --ref fix/ci-widgets-dependencies```

The test run can be seen in the actions tab on github here: https://github.com/worldbank/DECAT_Space2Stats/actions/runs/16023331907

Clicking on this action, you can see that the widget dependencies (ie. ipywidgets etc) were successfully installed, and all the tests passed. 