### PR TITLE
Extract adm2 summaries to json

### DIFF
--- a/space2stats_client/README.md
+++ b/space2stats_client/README.md
@@ -133,13 +133,13 @@ Gets timeseries data for specific H3 hexagon IDs.
 
 Access pre-computed administrative level 2 (ADM2) summaries from the World Bank Development Data Hub.
 
-### `get_adm2_dataset_info()`
-Returns information about available ADM2 datasets.
-- **Returns:** DataFrame with dataset names, resource IDs, descriptions, and URLs
+### `get_adm2_datasets()`
+Returns information about available ADM2 datasets from the World Bank DDH catalog.
+- **Returns:** DataFrame indexed by dataset name with columns: `description`, `metadata`, `resources` (dict of year → resource ID), and `data_urls` (dict of year → full API URL)
 
 ---
 
-### `get_adm2_summaries(dataset, iso3_filter=None)`
+### `get_adm2_summaries(dataset, year=None, iso3_filter=None)`
 Retrieves ADM2-level summary statistics from the World Bank DDH API.
 - **Parameters:**
   - `dataset`: Dataset to retrieve. Options:
@@ -147,6 +147,7 @@ Retrieves ADM2-level summary statistics from the World Bank DDH API.
     - `"nighttimelights"`: Nighttime lights intensity data (satellite-derived luminosity)
     - `"population"`: Population statistics (demographic data)
     - `"flood_exposure"`: Flood exposure risk data (flood hazard and exposure metrics)
+  - `year`: Optional year/version of the dataset. Defaults to the latest available. See `get_adm2_datasets()` for available years.
   - `iso3_filter`: Optional ISO3 country code to filter by (e.g., 'USA', 'BRA', 'IND')
   - `verbose`: Optional boolean to display progress messages
 - **Returns:** DataFrame containing ADM2-level statistics records
@@ -314,15 +315,16 @@ timeseries = client.get_timeseries(
     geometry="polygon"         # Optional
 )
 
+# Browse available ADM2 datasets
+adm2_info = client.get_adm2_datasets()
+print(adm2_info)
+
 # Get ADM2 summaries for a specific country
 adm2_pop = client.get_adm2_summaries(
     dataset="population",
-    iso3_filter="USA"  # Optional country filter
+    year="2020",           # Optional year selection
+    iso3_filter="USA"      # Optional country filter
 )
-
-# Get all available ADM2 datasets info
-adm2_info = client.get_adm2_dataset_info()
-print(adm2_info)
 ```
 ## Documentation
 

--- a/space2stats_client/pyproject.toml
+++ b/space2stats_client/pyproject.toml
@@ -41,6 +41,9 @@ Homepage = "https://github.com/worldbank/DECAT_Space2Stats.git"
 Documentation = "https://worldbank.github.io/DECAT_Space2Stats/"
 Repository = "https://github.com/worldbank/DECAT_Space2Stats.git"
 
+[tool.setuptools.package-data]
+space2stats_client = ["*.json"]
+
 [tool.poetry.group.test.dependencies]
 pytest = "*"
 pytest-mock = "*"

--- a/space2stats_client/src/space2stats_client/client.py
+++ b/space2stats_client/src/space2stats_client/client.py
@@ -3,6 +3,7 @@
 import inspect
 import json
 import urllib
+from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
 import geopandas as gpd
@@ -11,6 +12,10 @@ import requests
 from pystac import Catalog
 
 from .utils import download_esri_boundaries
+
+_DDH_CONFIG_PATH = Path(__file__).parent / "ddh_datasets.json"
+with open(_DDH_CONFIG_PATH, encoding="utf-8") as _f:
+    _DDH_CONFIG = json.load(_f)
 
 
 class Space2StatsClient:
@@ -604,22 +609,13 @@ class Space2StatsClient:
         return pd.DataFrame(timeseries_data)
 
     # ADM2 Summaries functionality for World Bank DDH API
-    WORLD_BANK_DDH_DATASETS = {
-        "urbanization": "DR0095357",
-        "nighttimelights": "DR0095356",
-        "population": "DR0095354",
-        "flood_exposure": "DR0095355",
-    }
-
-    WORLD_BANK_DDH_BASE_URL = (
-        "https://datacatalogapi.worldbank.org/ddhxext/v3/resources"
-    )
 
     def get_adm2_summaries(
         self,
         dataset: Literal[
             "urbanization", "nighttimelights", "population", "flood_exposure"
         ],
+        year: Optional[str] = None,
         iso3_filter: Optional[str] = None,
         verbose: bool = True,
     ) -> pd.DataFrame:
@@ -633,6 +629,9 @@ class Space2StatsClient:
             - "nighttimelights": Nighttime lights intensity data
             - "population": Population statistics
             - "flood_exposure": Flood exposure risk data
+        year : Optional[str]
+            The year/version of the dataset to retrieve. If None, defaults to the
+            latest available year. Available years can be found via get_adm2_datasets().
         iso3_filter : Optional[str]
             ISO3 country code to filter by (e.g., 'AND' for Andorra, 'USA' for United States)
         verbose : bool
@@ -646,22 +645,37 @@ class Space2StatsClient:
         Raises
         ------
         ValueError
-            If an invalid dataset is specified
+            If an invalid dataset or year is specified
         Exception
             If the API request fails
         """
-        if dataset not in self.WORLD_BANK_DDH_DATASETS:
+        datasets_config = _DDH_CONFIG["datasets"]
+        base_url = _DDH_CONFIG["base_url"]
+
+        if dataset not in datasets_config:
             raise ValueError(
-                f"Invalid dataset. Must be one of: {list(self.WORLD_BANK_DDH_DATASETS.keys())}"
+                f"Invalid dataset. Must be one of: {list(datasets_config.keys())}"
             )
+
+        available_resources = datasets_config[dataset]["datasets"]
+
+        if year is not None:
+            if year not in available_resources:
+                raise ValueError(
+                    f"Year '{year}' not available for '{dataset}'. "
+                    f"Available: {list(available_resources.keys())}"
+                )
+            resource_id = available_resources[year]
+        else:
+            # Default to the latest (last) entry
+            resource_id = list(available_resources.values())[-1]
 
         if verbose:
             print(f"Fetching {dataset} data from World Bank DDH API...")
             if iso3_filter:
                 print(f"Filtering by ISO3: {iso3_filter}")
 
-        resource_id = self.WORLD_BANK_DDH_DATASETS[dataset]
-        url = f"{self.WORLD_BANK_DDH_BASE_URL}/{resource_id}/data"
+        url = f"{base_url}/{resource_id}/data"
 
         # Build query parameters
         params = {}
@@ -690,39 +704,34 @@ class Space2StatsClient:
         except Exception as e:
             raise Exception(f"Error processing World Bank DDH API response: {e}")
 
-    def get_adm2_dataset_info(self) -> pd.DataFrame:
-        """Get information about available ADM2 datasets.
+    def get_adm2_datasets(self) -> pd.DataFrame:
+        """Get information about available ADM2 datasets from the World Bank DDH catalog.
 
         Returns
         -------
         DataFrame
-            A DataFrame with information about each available ADM2 dataset
+            A DataFrame indexed by dataset name with columns:
+            - description: Human-readable description of the dataset
+            - metadata: Link to the DDH catalog page
+            - resources: Dict of year/version to resource ID
+            - data_urls: Dict of year/version to full API data URL
         """
-        datasets_info = [
-            {
-                "dataset": "urbanization",
-                "resource_id": "DR0095357",
-                "description": "Urban and rural settlement data - GHS settlement model data",
-                "url": f"{self.WORLD_BANK_DDH_BASE_URL}/DR0095357/data",
-            },
-            {
-                "dataset": "nighttimelights",
-                "resource_id": "DR0095356",
-                "description": "Nighttime lights intensity data - satellite-derived luminosity measurements",
-                "url": f"{self.WORLD_BANK_DDH_BASE_URL}/DR0095356/data",
-            },
-            {
-                "dataset": "population",
-                "resource_id": "DR0095354",
-                "description": "Population statistics - demographic data",
-                "url": f"{self.WORLD_BANK_DDH_BASE_URL}/DR0095354/data",
-            },
-            {
-                "dataset": "flood_exposure",
-                "resource_id": "DR0095355",
-                "description": "Flood exposure risk data - flood hazard and exposure metrics",
-                "url": f"{self.WORLD_BANK_DDH_BASE_URL}/DR0095355/data",
-            },
-        ]
+        datasets_config = _DDH_CONFIG["datasets"]
+        base_url = _DDH_CONFIG["base_url"]
 
-        return pd.DataFrame(datasets_info)
+        rows = []
+        for name, info in datasets_config.items():
+            data_urls = {
+                yr: f"{base_url}/{rid}/data" for yr, rid in info["datasets"].items()
+            }
+            rows.append(
+                {
+                    "dataset": name,
+                    "description": info["description"],
+                    "metadata": info["metadata"],
+                    "resources": info["datasets"],
+                    "data_urls": data_urls,
+                }
+            )
+
+        return pd.DataFrame(rows).set_index("dataset")

--- a/space2stats_client/src/space2stats_client/ddh_datasets.json
+++ b/space2stats_client/src/space2stats_client/ddh_datasets.json
@@ -1,0 +1,33 @@
+{
+  "base_url": "https://datacatalogapi.worldbank.org/ddhxext/v3/resources",
+  "datasets": {
+    "urbanization": {
+      "description": "Urban and rural settlement data - GHS settlement model data",
+      "metadata": "https://datacatalog.worldbank.org/search/dataset/DR0095357",
+      "datasets": {
+        "2012": "DR0095357"
+      }
+    },
+    "nighttimelights": {
+      "description": "Nighttime lights intensity data - satellite-derived luminosity measurements",
+      "metadata": "https://datacatalog.worldbank.org/search/dataset/DR0095356",
+      "datasets": {
+        "2020": "DR0095356"
+      }
+    },
+    "population": {
+      "description": "Population statistics - demographic data",
+      "metadata": "https://datacatalog.worldbank.org/search/dataset/DR0095354",
+      "datasets": {
+        "2020": "DR0095354"
+      }
+    },
+    "flood_exposure": {
+      "description": "Flood exposure risk data - flood hazard and exposure metrics",
+      "metadata": "https://datacatalog.worldbank.org/search/dataset/DR0095355",
+      "datasets": {
+        "2020": "DR0095355"
+      }
+    }
+  }
+}

--- a/space2stats_client/tests/test_client.py
+++ b/space2stats_client/tests/test_client.py
@@ -266,16 +266,17 @@ def test_handle_api_error_503(mock_error_response_503):
     assert str(exc_info.value).strip() == expected_message
 
 
-def test_get_adm2_dataset_info():
-    """Test get_adm2_dataset_info returns correct DataFrame structure."""
+def test_get_adm2_datasets():
+    """Test get_adm2_datasets returns correct DataFrame structure."""
     client = Space2StatsClient()
-    result = client.get_adm2_dataset_info()
+    result = client.get_adm2_datasets()
 
     assert isinstance(result, pd.DataFrame)
-    assert len(result) == 4  # Four datasets available
+    assert result.index.name == "dataset"
+    assert len(result) == 4
 
     # Check required columns
-    expected_columns = ["dataset", "resource_id", "description", "url"]
+    expected_columns = ["description", "metadata", "resources", "data_urls"]
     for col in expected_columns:
         assert col in result.columns
 
@@ -287,10 +288,22 @@ def test_get_adm2_dataset_info():
         "flood_exposure",
     ]
     for dataset in expected_datasets:
-        assert dataset in result["dataset"].values
+        assert dataset in result.index
 
-    # Check resource IDs format
-    assert all(result["resource_id"].str.startswith("DR"))
+    # Check resources are dicts with resource IDs
+    for dataset in expected_datasets:
+        resources = result.loc[dataset, "resources"]
+        assert isinstance(resources, dict)
+        assert len(resources) > 0
+        for rid in resources.values():
+            assert rid.startswith("DR")
+
+    # Check data_urls are constructed correctly
+    for dataset in expected_datasets:
+        data_urls = result.loc[dataset, "data_urls"]
+        assert isinstance(data_urls, dict)
+        for url in data_urls.values():
+            assert "datacatalogapi.worldbank.org" in url
 
 
 def test_get_adm2_summaries_invalid_dataset():
@@ -298,6 +311,22 @@ def test_get_adm2_summaries_invalid_dataset():
     client = Space2StatsClient()
     with pytest.raises(ValueError, match="Invalid dataset. Must be one of:"):
         client.get_adm2_summaries(dataset="invalid_dataset")
+
+
+def test_get_adm2_summaries_invalid_year():
+    """Test that invalid year raises ValueError."""
+    client = Space2StatsClient()
+    with pytest.raises(ValueError, match="Year .* not available for"):
+        client.get_adm2_summaries(dataset="population", year="9999")
+
+
+def test_get_adm2_summaries_with_year(mock_adm2_response):
+    """Test get_adm2_summaries with explicit year parameter."""
+    client = Space2StatsClient()
+    result = client.get_adm2_summaries(dataset="population", year="2020")
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
 
 
 def test_get_adm2_summaries_population(mock_adm2_response):


### PR DESCRIPTION
## What I changed

Extracted hardcoded ADM2 dataset config from `client.py` into a standalone `ddh_datasets.json` — single source of truth that supports multiple resource links per topic for upcoming multi-year datasets.

- **New:** `ddh_datasets.json` with `description`, `metadata` link, and `datasets` dict (year → resource ID)
- **Replaced** `get_adm2_dataset_info()` with `get_adm2_datasets()` — richer DataFrame output
- **Added** `year` parameter to `get_adm2_summaries()` (defaults to latest)
- **Updated** `pyproject.toml`, README, and tests

## How to test

```bash
cd space2stats_client
python -m pytest tests/test_client.py -v -k "adm2"
```

```python
from space2stats_client import Space2StatsClient
client = Space2StatsClient()
print(client.get_adm2_datasets())
df = client.get_adm2_summaries("population", iso3_filter="AND")
```