### PR TITLE
Fix destroy yml workflow

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -50,7 +50,7 @@ jobs:
           CDK_DEFAULT_REGION: ${{ vars.CDK_DEFAULT_REGION }}
           CDK_DOMAIN_NAME: ${{ vars.CDK_DOMAIN_NAME }}
           CDK_DISABLE_CLI_TELEMETRY: "true" 
-        run: cdk destroy --require-approval never
+        run: cdk destroy --force
 
       - name: Find Comment
         uses: peter-evans/find-comment@v3


### PR DESCRIPTION
The "Destroy Preview Environment" workflow was failing at the cdk destroy step with terminal (TTY) is not attached so we are unable to get a confirmation from the user. --require-approval never only suppresses the security-change prompt on cdk deploy — it has no effect on the destroy confirmation. Replaced it with --force, which is the correct flag to skip the confirmation in non-interactive environments like GitHub Actions.